### PR TITLE
Empty template variable for OutboundBindAddress if param is an empty array (#2)

### DIFF
--- a/manifests/daemon/relay.pp
+++ b/manifests/daemon/relay.pp
@@ -24,7 +24,7 @@ define tor::daemon::relay(
   $nickname = $name
 
   if $outbound_bindaddresses == [] {
-    $real_outbound_bindaddresses = $listen_addresses
+    $real_outbound_bindaddresses = ''
   } else {
     $real_outbound_bindaddresses = $outbound_bindaddresses
   }


### PR DESCRIPTION
Before this, the listenaddresses were copied.
Since setting OutboundBindAddress looks like a setting that the Tor operator must set knowingly because of security implications:
http://en.linuxreviews.org/HOWTO_setup_a_Tor-server
http://superuser.com/questions/461167/forcing-tor-to-use-a-given-ip-address-for-outbound-connections
Seems more safe to delete OBA if not set, allowing the Tor route to behave as default instead of setting it without the Tor operator's knowledge. Worst case, the operator may be adding to listen addresses a private LAN address besides a public WAN IP, and unknowingly adding both to OBA.
