### PR TITLE
Add PortForwarding to allow UPnP firewall pf configuration.

### DIFF
--- a/README
+++ b/README
@@ -133,6 +133,8 @@ You have the following options that can be passed to a relay, with the defaults 
  
 $port                    = 0,
 $listen_addresses        = [],
+$portforwarding          = 0,     # PortForwarding 0|1, set for opening ports at the router via UPnP.
+                                  # Requires 'tor-fw-helper' binary present.
 $bandwidth_rate          = '',    # KB/s, defaulting to using tor's default: 5120KB/s
 $bandwidth_burst         = '',    # KB/s, defaulting to using tor's default: 10240KB/s
 $relay_bandwidth_rate    = 0,     # KB/s, 0 for no limit.

--- a/manifests/daemon/relay.pp
+++ b/manifests/daemon/relay.pp
@@ -3,6 +3,7 @@ define tor::daemon::relay(
   $port                    = 0,
   $listen_addresses        = [],
   $outbound_bindaddresses  = [],
+  $portforwarding          = 0,
   # KB/s, defaulting to using tor's default: 5120KB/s
   $bandwidth_rate          = '',
   # KB/s, defaulting to using tor's default: 10240KB/s

--- a/templates/torrc.relay.erb
+++ b/templates/torrc.relay.erb
@@ -13,6 +13,9 @@ Nickname <%= nickname %>
 <%-   if address != '' then -%>
 Address <%= address %>
 <%-   end -%>
+<%-   if portforwarding != '0' then -%>
+PortForwarding <%= portforwarding %>
+<%-   end -%>
 <%-   if bandwidth_rate != '' then -%>
 BandwidthRate <%= bandwidth_rate %> KB
 <%-   end -%>
@@ -41,4 +44,3 @@ MyFamily <%= my_family %>
 <%- if bridge_relay != '0' then -%>
 BridgeRelay <%= bridge_relay %>
 <%- end -%>
-


### PR DESCRIPTION
Requires 'tor-fw-helper' binary present. If not, the relay will work but log:

```
[WARN] Failed to start child process "tor-fw-helper" in state 9: No such file or directory
```

It should be compiled from source. Packaging is underway at https://trac.torproject.org/projects/tor/ticket/3378
